### PR TITLE
Disable widget updates if `CallTreeLayout.treeview` is hidden.

### DIFF
--- a/calltree.py
+++ b/calltree.py
@@ -266,6 +266,9 @@ class CallTreeLayout(QVBoxLayout):
                         )
 
     def update_widget(self, cur_func: Function):
+        if not self.treeview.isVisible():
+            return
+        
         # Clear previous calls
         self.clear()
         call_root_node = self.model.invisibleRootItem()


### PR DESCRIPTION
Hello, many thanks for this plugin!

This PR disables the updates if the tree view widget is hidden, preventing noticeable UI freezes for functions with a lot of incoming and outgoing calls.